### PR TITLE
Added Content-ID header to the MIME Part

### DIFF
--- a/include/esmtp_mime.hrl
+++ b/include/esmtp_mime.hrl
@@ -12,6 +12,6 @@
                     encoding = {"7bit", "text/plain","iso-8859-1"},
                     name,
                     data,
-                    content_id = undefined}).
+                    content_id}).
 
 -endif.

--- a/include/esmtp_mime.hrl
+++ b/include/esmtp_mime.hrl
@@ -11,6 +11,7 @@
 -record(mime_part, {type,
                     encoding = {"7bit", "text/plain","iso-8859-1"},
                     name,
-                    data}).
+                    data,
+                    content_id = undefined}).
 
 -endif.

--- a/src/esmtp_mime.erl
+++ b/src/esmtp_mime.erl
@@ -110,13 +110,28 @@ part_headers(#mime_part{type=undefined, encoding={Enc, MimeType, Charset},
                         name=undefined}) ->
     [{"Content-Transfer-Encoding", Enc},
      {"Content-Type", [MimeType, {charset, Charset}]}];
-part_headers(#mime_part{type=Type, encoding={Enc, MimeType, Charset},
-                        name=Name}) when Type==inline; Type == attachment ->
+
+part_headers(#mime_part{type=Type,
+                        encoding={Enc, MimeType, Charset},
+                        name=Name,
+                        content_id=undefined}) when Type==inline; Type == attachment ->
     [{"Content-Transfer-Encoding", Enc},
      {"Content-Type", [MimeType, "charset=" ++ Charset ++ ",name=" ++ Name]},
-     {"Content-Disposition", [atom_to_list(Type), 
-                              {"filename", 
-                              Name}]}].
+     {"Content-Disposition", [atom_to_list(Type),
+                              {"filename",
+                              Name}]}];
+
+part_headers(#mime_part{type=Type,
+                        encoding={Enc, MimeType, Charset},
+                        name=Name,
+                        content_id=Id}) when Type==inline; Type == attachment ->
+    [{"Content-Transfer-Encoding", Enc},
+     {"Content-Type", [MimeType, "charset=" ++ Charset ++ ",name=" ++ Name]},
+     {"Content-Disposition", [atom_to_list(Type),
+                              {"filename",
+                              Name}]},
+     {"Content-ID", "<" ++ Id ++">"}
+    ].
 
 headers(#mime_msg{headers=H, boundary=Boundary}) ->
     H ++ [{"MIME-Version", "1.0"},


### PR DESCRIPTION
I have added content_id field to the the #mime_part record with a default undefined value. If the content_id is defined then a new Content-ID header is set so the MIME part can be referenced from another parts of the mail.
