### PR TITLE
Duplicate module in app file

### DIFF
--- a/ebin/esmtp.app
+++ b/ebin/esmtp.app
@@ -5,7 +5,6 @@
   ,{modules, [esmtp
               ,esmtp_app
               ,esmtp_client
-              ,esmtp_sock
               ,esmtp_codec
               ,esmtp_mime
               ,esmtp_sock


### PR DESCRIPTION
systools:make_script/2 complains when a module is duplicated in an .app file.
