### PR TITLE
Replace start_ssl with ensure_all_started.

### DIFF
--- a/src/esmtp_app.erl
+++ b/src/esmtp_app.erl
@@ -75,14 +75,5 @@ need_ssl(?SMTP_PORT_TLS) -> true;
 need_ssl(?SMTP_PORT_SSL) -> true;
 need_ssl(_) -> false.
 
-ensure_started(App) ->
-    case application:start(App) of
-        ok -> ok;
-        {error, {already_started, App}} -> ok;
-        Err -> Err
-    end.
-
 start_ssl() ->
-    ok = ensure_started(crypto),
-    ok = ensure_started(public_key),
-    ok = ensure_started(ssl).
+    application:ensure_all_started(ssl).


### PR DESCRIPTION
We no longer need to use our own all started method - application:ensure_all_started/1 should do the trick instead.
